### PR TITLE
Change $_POST to $_GET to match form

### DIFF
--- a/public_html/search.php
+++ b/public_html/search.php
@@ -5,7 +5,7 @@
 
     try {
         $ctx = PrismicHelper::context();
-        $maybeQuery = isset($_POST['q']) ? $_POST['q'] : '';
+        $maybeQuery = isset($_GET['q']) ? $_GET['q'] : '';
         $q = '[[:d = fulltext(document, "' . $maybeQuery . '")]]';
         $documents = $ctx->getApi()->forms()->everything->query($q)->ref($ctx->getRef())->submit();
     } catch (Guzzle\Http\Exception\BadResponseException $e) {


### PR DESCRIPTION
The form in index.php has method="GET", but search.php expects POST. This means that search is currently broken.